### PR TITLE
Brute and burn create more wounds

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -94,7 +94,8 @@
 	if(!damage_type || status & ORGAN_DEAD)
 		return FALSE
 
-	var/wound_count = max(0, round((amount * wounding_multiplier) / 8))	// At base values, every 8 points of damage is 1 wound
+	var/wound_threshold = (damage_type == BRUTE || damage_type == BURN) ? 4 : 8
+	var/wound_count = max(0, round((amount * wounding_multiplier) / wound_threshold))
 
 	if(!wound_count)
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This will make brute and burn damage create twice as many wounds.

## Why It's Good For The Game

Lethal

## Changelog
:cl:
tweak: Brute and burn damage create twice as many wounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
